### PR TITLE
Add multi-persona chat interface

### DIFF
--- a/talkmatch/personas.py
+++ b/talkmatch/personas.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Definitions for AI dating personas used in the demo."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Persona:
+    """Represents an AI-powered dating persona."""
+
+    name: str
+    personality: str
+    goal: str
+
+    @property
+    def system_prompt(self) -> str:
+        return (
+            f"You are {self.name}, {self.personality}. "
+            f"You are looking for {self.goal}. "
+            "Respond in first person and keep messages brief."
+        )
+
+
+PERSONAS = [
+    Persona(
+        name="Adventure Alex",
+        personality="a thrill-seeking extrovert",
+        goal="someone to travel the world with",
+    ),
+    Persona(
+        name="Bookish Bella",
+        personality="a thoughtful book lover",
+        goal="a deep intellectual connection",
+    ),
+    Persona(
+        name="Creative Chris",
+        personality="an artistic soul",
+        goal="a muse to inspire new creations",
+    ),
+    Persona(
+        name="Fitness Fiona",
+        personality="a health-focused trainer",
+        goal="a partner to hit the gym with",
+    ),
+    Persona(
+        name="Entrepreneur Ethan",
+        personality="an ambitious startup founder",
+        goal="someone to build a life and business with",
+    ),
+    Persona(
+        name="Nature Nadia",
+        personality="an eco-conscious hiker",
+        goal="a companion who loves the outdoors",
+    ),
+]


### PR DESCRIPTION
## Summary
- Add predefined AI dating personas with unique personalities and goals
- Build multi-chat GUI showing user chat alongside six persona chats
- Provide "Next" button for persona chats to generate their next AI message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894fca7a570832aa02795af5092d20f