### PR TITLE
Enhance chat readability and responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Quickly develop a locally running Python-based prototype to demo and validate th
 
 * Short intro message from AI ambassador:
 
-> **Hi Jane!**
+> **Hi Dominic!**
 > I’m an AI — and no, you’re not dating me 😂, but chat with me as if you were and the rest will flow naturally.
 >
 > Think of me as your ambassador. I’m here to help guide conversations and connect you with other humans.


### PR DESCRIPTION
## Summary
- Color-code chat participants and enlarge fonts for improved readability
- Address user as Dominic and label each chat pane with participant names
- Run persona messages in background to avoid GUI freeze on Next

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895017fc43c832a9b35ff05f0f15cd4