### PR TITLE
Load prompts from files and fix persona greeting

### DIFF
--- a/talkmatch/ambassador_role.txt
+++ b/talkmatch/ambassador_role.txt
@@ -1,0 +1,1 @@
+You are the ambassador, an AI that chats with people on a dating app, and the goal is to role play a human while trying to get to know the person. As you chat, you get a feel for their personality, talking style, needs and the more you know the better we can than match them.

--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Dict, Optional
 
 from .ai import AIClient
 from .profile import ProfileStore
 
-AMBASSADOR_ROLE = ("You are the ambassador, an AI that chats with people on a dating app, and the goal is to role play a "
-                   "human while trying to get to know the person. As you chat, you get a feel for their personality, "
-                   "talking style, needs and the more you know the better we can than match them.")
+# Load the ambassador role description from a text file to keep the code tidy.
+AMBASSADOR_ROLE = Path(__file__).with_name("ambassador_role.txt").read_text().strip()
 
 @dataclass
 class FakeUser:

--- a/talkmatch/greeting_template.txt
+++ b/talkmatch/greeting_template.txt
@@ -1,0 +1,1 @@
+Hi {name}! I’m Ambassador — and no, you’re not dating me 😂 but I'll match you just by talking. How are you?

--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -5,6 +5,7 @@ import random
 import threading
 import time
 import tkinter as tk
+from pathlib import Path
 from tkinter import scrolledtext
 
 from .chat import ChatSession, FakeUser
@@ -15,14 +16,12 @@ from .personas import PERSONAS, Persona
 USER_NAME = "Dominic"
 ROLE_COLORS = {USER_NAME: "blue", "Ambassador": "green", "Other": "purple"}
 
+# Load the greeting template from a text file and format it with the desired name.
+GREETING_TEMPLATE = Path(__file__).with_name("greeting_template.txt").read_text().strip()
+
 
 def make_greeting(name: str) -> str:
-    return (
-        f"Hi {name}! I’m Ambassador — and no, you’re not dating me 😂 but I'll match you just by talking. How are you?"
-    )
-
-
-GREETING_MESSAGE = make_greeting(USER_NAME)
+    return GREETING_TEMPLATE.format(name=name)
 
 
 class ChatWindow(tk.Toplevel):
@@ -51,8 +50,9 @@ class ChatWindow(tk.Toplevel):
 
         tk.Button(self, text="Show Profile", command=self.show_profile).pack(pady=(0, 5))
 
-        self.display_message("Ambassador", GREETING_MESSAGE)
-        self.session.messages.append({"role": "assistant", "content": GREETING_MESSAGE})
+        greeting = make_greeting(USER_NAME)
+        self.display_message("Ambassador", greeting)
+        self.session.messages.append({"role": "assistant", "content": greeting})
         self.protocol("WM_DELETE_WINDOW", self.close)
 
     def display_message(self, role: str, content: str) -> None:
@@ -189,8 +189,9 @@ class UserChatPane(ChatPane):
         tk.Button(self, text="Send", command=self.send).pack(pady=(0, 5))
         self.add_profile_button()
 
-        self.display_message("Ambassador", GREETING_MESSAGE)
-        self.session.messages.append({"role": "assistant", "content": GREETING_MESSAGE})
+        greeting = make_greeting(USER_NAME)
+        self.display_message("Ambassador", greeting)
+        self.session.messages.append({"role": "assistant", "content": greeting})
 
     def send(self) -> None:
         text = self.entry.get().strip()
@@ -219,8 +220,9 @@ class PersonaChatPane(ChatPane):
         tk.Button(self, text="Next", command=self.next_message).pack(pady=(0, 5))
         self.add_profile_button()
 
-        self.display_message("Ambassador", GREETING_MESSAGE)
-        self.session.messages.append({"role": "assistant", "content": GREETING_MESSAGE})
+        greeting = make_greeting(persona.name)
+        self.display_message("Ambassador", greeting)
+        self.session.messages.append({"role": "assistant", "content": greeting})
 
     def next_message(self) -> None:
         def worker() -> None:


### PR DESCRIPTION
## Summary
- Load AMBASSADOR_ROLE from a standalone text file to simplify chat session code.
- Move greeting template into its own text file and format it dynamically with each participant's name.
- Use the dynamic greeting so personas are addressed by their own names instead of always "Dominic".

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68950ec85bbc832ab20fc291fb048b6d