### PR TITLE
Summarize user profiles using build_profile instructions

### DIFF
--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -43,7 +43,7 @@ class ChatSession:
         """Handle a message from any client (user or persona)."""
 
         self.messages.append({"role": "user", "content": text})
-        self.profile_store.append(name, text)
+        self.profile_store.update(self.ai_client, name, text)
         if self.fake_user:
             reply = self.fake_user.get_reply()
         else:

--- a/talkmatch/profile.py
+++ b/talkmatch/profile.py
@@ -5,20 +5,30 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from .ai import AIClient
+
 
 @dataclass
 class ProfileStore:
-    """Persist conversation snippets per user."""
+    """Persist conversation summaries per user."""
 
     base_dir: Path = Path("user_profiles")
+    prompt_template: str = (
+        Path(__file__).with_name("build_profile.txt").read_text(encoding="utf-8")
+    )
 
     def __post_init__(self) -> None:
         self.base_dir.mkdir(exist_ok=True)
 
-    def append(self, user: str, text: str) -> None:
+    def update(self, ai_client: AIClient, user: str, text: str) -> None:
+        """Send new chat text to the AI and persist the updated profile."""
+
         path = self.base_dir / f"{user}.txt"
-        with path.open("a", encoding="utf-8") as f:
-            f.write(text + "\n")
+        existing = path.read_text(encoding="utf-8").strip() if path.exists() else ""
+        combined = f"{existing}\n{text}" if existing else text
+        prompt = self.prompt_template.replace("{info}", combined)
+        response = ai_client.get_response([{"role": "user", "content": prompt}])
+        path.write_text(response + "\n", encoding="utf-8")
 
     def read(self, user: str) -> str:
         path = self.base_dir / f"{user}.txt"

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -8,23 +8,29 @@ from talkmatch.profile import ProfileStore
 
 
 class DummyAI:
+    def __init__(self, responses):
+        self.responses = responses
+        self.index = 0
+
     def get_response(self, messages):
-        return "AI reply"
+        resp = self.responses[self.index]
+        self.index += 1
+        return resp
 
 
 def test_chat_session_uses_ai(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
-    session = ChatSession(ai_client=DummyAI(), profile_store=store)
+    session = ChatSession(ai_client=DummyAI(["Stored profile", "AI reply"]), profile_store=store)
     reply = session.send_client_message("Alice", "Hello")
     assert reply == "AI reply"
-    assert (tmp_path / "Alice.txt").read_text().strip() == "Hello"
+    assert (tmp_path / "Alice.txt").read_text().strip() == "Stored profile"
 
 
 def test_chat_session_switch_to_fake_user(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
-    session = ChatSession(ai_client=DummyAI(), profile_store=store)
+    session = ChatSession(ai_client=DummyAI(["Stored profile"]), profile_store=store)
     fake = FakeUser(["Hi I'm fake"])
     session.switch_to_fake_user(fake)
     reply = session.send_client_message("Bob", "Hello")
     assert reply == "Hi I'm fake"
-    assert (tmp_path / "Bob.txt").read_text().strip() == "Hello"
+    assert (tmp_path / "Bob.txt").read_text().strip() == "Stored profile"


### PR DESCRIPTION
## Summary
- Maintain user profile summaries by prompting the AI with `build_profile.txt` each time chat text arrives
- Chat sessions now update the profile store so information is continuously absorbed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68951cb7bc88832abac33c6e8de647ff