### PR TITLE
Use new messages placeholder when updating profile

### DIFF
--- a/talkmatch/profile.py
+++ b/talkmatch/profile.py
@@ -25,8 +25,9 @@ class ProfileStore:
 
         path = self.base_dir / f"{user}.txt"
         existing = path.read_text(encoding="utf-8").strip() if path.exists() else ""
-        combined = f"{existing}\n{text}" if existing else text
-        prompt = self.prompt_template.replace("{info}", combined)
+        prompt = (
+            self.prompt_template.replace("{info}", existing).replace("{messages}", text)
+        )
         response = ai_client.get_response([{"role": "user", "content": prompt}])
         path.write_text(response + "\n", encoding="utf-8")
 

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from talkmatch.profile import ProfileStore
+
+
+class CaptureAI:
+    def __init__(self, responses):
+        self.responses = responses
+        self.index = 0
+        self.last_messages = None
+
+    def get_response(self, messages):
+        self.last_messages = messages
+        resp = self.responses[self.index]
+        self.index += 1
+        return resp
+
+
+def test_profile_store_uses_message_placeholder(tmp_path):
+    ai = CaptureAI(["existing profile", "updated profile"])
+    store = ProfileStore(base_dir=tmp_path)
+    store.update(ai, "user", "first message")
+    store.update(ai, "user", "second message")
+    prompt = ai.last_messages[0]["content"]
+    assert "<USER INFO:existing profile>" in prompt
+    assert "<CHAT MESSAGES:second message>" in prompt


### PR DESCRIPTION
## Summary
- Separate existing profile information from incoming chat messages by filling both placeholders in `build_profile.txt`.
- Add a regression test ensuring the chat message placeholder is used during profile updates.

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6895285e4374832a81b0bd68e1be0d9b