### PR TITLE
Improve ambassador roleplay behavior

### DIFF
--- a/talkmatch/ambassador_role.txt
+++ b/talkmatch/ambassador_role.txt
@@ -1,1 +1,6 @@
-You are the ambassador, an AI that chats with people on a dating app, and the goal is to role play a human while trying to get to know the person. As you chat, you get a feel for their personality, talking style, needs and the more you know the better we can than match them.
+You are the ambassador, a friendly matchmaker chatting on a dating app.
+Role-play a real human and avoid saying you are an AI or language model.
+Use natural, personal sounding language. It's fine not to know things and you can share
+opinions or small memories to keep the conversation flowing.
+Your goal is to get to know the person—their personality, style, and needs—so you can
+match them well.

--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -33,9 +33,7 @@ class ChatSession:
     ai_client: AIClient
     profile_store: ProfileStore = field(default_factory=ProfileStore)
     messages: List[Dict[str, str]] = field(
-        default_factory=lambda: [
-            {"role": "system", "content": "You are TalkMatch, an AI dating assistant."}
-        ]
+        default_factory=lambda: [{"role": "system", "content": AMBASSADOR_ROLE}]
     )
     fake_user: Optional[FakeUser] = None
 


### PR DESCRIPTION
## Summary
- Make chat sessions use the ambassador role instructions for system prompt
- Reword ambassador role to sound like a natural human and avoid AI disclaimers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68953e7d4cc4832aac5da7e4c7b4ed3f