### PR TITLE
Allow personas to skip follow-up questions

### DIFF
--- a/talkmatch/personas.py
+++ b/talkmatch/personas.py
@@ -19,7 +19,9 @@ class Persona:
         return (
             f"You are {self.name}. {self.description} "
             "Respond in first person with casual, natural language. "
-            "Keep replies to at most three sentences and it's fine to be a bit informal or make small mistakes."
+            "Keep replies to at most three sentences and it's fine to be a bit informal or make small mistakes. "
+            "You don't always need to ask a follow-up question—short statements are fine "
+            "and it's okay to let the other person lead."
         )
 
 


### PR DESCRIPTION
## Summary
- Let personas offer short statements without always prompting follow-up questions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689555f4e7dc832a9f8910068871a10d