### PR TITLE
Use AI for match scoring

### DIFF
--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -273,7 +273,7 @@ def run_app() -> None:
         panes[persona.name] = pane
 
     def calculate() -> None:
-        matcher.calculate()
+        matcher.calculate(AIClient())
         for name, pane in panes.items():
             pane.update_match_display(matcher.top_matches(name))
 

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,15 +1,38 @@
-import random
+from __future__ import annotations
+
+"""Tests for the AI-based matcher."""
 
 from talkmatch.matcher import Matcher
 
 
-def test_top_matches_deterministic():
+class DummyAI:
+    """Return predetermined responses for each compatibility query."""
+
+    def __init__(self, responses: list[str]):
+        self.responses = responses
+
+    def get_response(self, messages):
+        return self.responses.pop(0)
+
+
+class DummyStore:
+    """Minimal profile store used for testing."""
+
+    def __init__(self, profiles):
+        self.profiles = profiles
+
+    def read(self, user: str) -> str:
+        return self.profiles.get(user, "")
+
+
+def test_top_matches_use_ai_scores():
     users = ["A", "B", "C"]
     matcher = Matcher(users)
-    random.seed(0)
-    matcher.calculate()
-    top = matcher.top_matches("A", top_n=2)
-    assert top[0][0] == "B"
-    assert abs(top[0][1] - 0.8444218515250481) < 1e-9
-    assert top[1][0] == "C"
-    assert abs(top[1][1] - 0.7579544029403025) < 1e-9
+
+    ai = DummyAI(["0.9", "0.6", "0.3"])
+    store = DummyStore({"A": "profile a", "B": "profile b", "C": "profile c"})
+
+    matcher.calculate(ai, profile_store=store)
+
+    assert matcher.top_matches("A", top_n=2) == [("B", 0.9), ("C", 0.6)]
+    assert matcher.top_matches("B", top_n=2) == [("A", 0.9), ("C", 0.3)]


### PR DESCRIPTION
## Summary
- replace random match scores with AI-driven compatibility ratings
- update GUI to request scores from the AI client
- add tests for AI-based matcher

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68955660514c832a85fd5d4c12341def