### PR TITLE
Ambassador adopts matched persona with message counts

### DIFF
--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -36,6 +36,8 @@ class ChatSession:
         default_factory=lambda: [{"role": "system", "content": AMBASSADOR_ROLE}]
     )
     fake_user: Optional[FakeUser] = None
+    matched_persona: Optional[str] = None
+    persona_message_counts: Dict[str, int] = field(default_factory=dict)
 
     def send_client_message(self, name: str, text: str) -> str:
         """Handle a message from any client (user or persona)."""
@@ -45,9 +47,26 @@ class ChatSession:
         if self.fake_user:
             reply = self.fake_user.get_reply()
         else:
-            reply = self.ai_client.get_response(self.messages)
+            messages = self.messages
+            if self.matched_persona:
+                profile = self.profile_store.read(self.matched_persona)
+                persona_prompt = (
+                    f"Act as {self.matched_persona} using this profile: {profile}. "
+                    "Maintain the current topic and shift gradually from the ambassador's tone to "
+                    f"{self.matched_persona}'s style."
+                )
+                messages = messages + [{"role": "system", "content": persona_prompt}]
+            reply = self.ai_client.get_response(messages)
         self.messages.append({"role": "assistant", "content": reply})
+        if self.matched_persona:
+            self.persona_message_counts[self.matched_persona] = (
+                self.persona_message_counts.get(self.matched_persona, 0) + 1
+            )
         return reply
 
     def switch_to_fake_user(self, fake_user: FakeUser) -> None:
         self.fake_user = fake_user
+
+    def set_persona(self, persona: Optional[str]) -> None:
+        """Switch the ambassador to act as a given persona."""
+        self.matched_persona = persona

--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -6,7 +6,7 @@ import time
 import tkinter as tk
 from pathlib import Path
 from tkinter import scrolledtext
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from .chat import ChatSession, FakeUser
 from .ai import AIClient
@@ -163,11 +163,18 @@ class ChatPane(tk.Frame):
     def add_match_area(self) -> None:
         self.match_area.pack(fill=tk.BOTH, expand=False, padx=5, pady=5)
 
-    def update_match_display(self, matches: List[Tuple[str, float]]) -> None:
+    def update_match_display(
+        self,
+        matches: List[Tuple[str, float]],
+        message_counts: Optional[Dict[str, int]] = None,
+    ) -> None:
         self.match_area.configure(state="normal")
         self.match_area.delete("1.0", tk.END)
         for name, score in matches:
-            self.match_area.insert(tk.END, f"{name}: {score:.2f}\n")
+            count = 0
+            if message_counts:
+                count = message_counts.get(name, 0)
+            self.match_area.insert(tk.END, f"{name}: {score:.2f} ({count} msgs)\n")
         self.match_area.configure(state="disabled")
 
     def show_profile(self) -> None:
@@ -274,8 +281,16 @@ def run_app() -> None:
 
     def calculate() -> None:
         matcher.calculate()
+        top = matcher.top_matches(USER_NAME, 1)
+        if top and top[0][1] > 0:
+            user_pane.session.set_persona(top[0][0])
+        else:
+            user_pane.session.set_persona(None)
+        msg_counts = user_pane.session.persona_message_counts
         for name, pane in panes.items():
-            pane.update_match_display(matcher.top_matches(name))
+            pane.update_match_display(
+                matcher.top_matches(name), message_counts=msg_counts
+            )
 
     tk.Button(root, text="Calculate matches", command=calculate).grid(
         row=1, column=0, columnspan=len(panes), pady=5

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -34,3 +34,15 @@ def test_chat_session_switch_to_fake_user(tmp_path):
     reply = session.send_client_message("Bob", "Hello")
     assert reply == "Hi I'm fake"
     assert (tmp_path / "Bob.txt").read_text().strip() == "Stored profile"
+
+
+def test_chat_session_tracks_persona_messages(tmp_path):
+    store = ProfileStore(base_dir=tmp_path)
+    (tmp_path / "Alex.txt").write_text("Profile", encoding="utf-8")
+    session = ChatSession(
+        ai_client=DummyAI(["Stored profile", "AI reply"]), profile_store=store
+    )
+    session.set_persona("Alex")
+    reply = session.send_client_message("Alice", "Hi")
+    assert reply == "AI reply"
+    assert session.persona_message_counts["Alex"] == 1


### PR DESCRIPTION
## Summary
- When matches are calculated, the ambassador now assumes the top matched persona's profile and gradually shifts tone to match their style.
- GUI match panels list message counts per persona, and the user session tracks exchanges for each persona.
- Added regression test verifying persona message tracking in chat sessions.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6895585d0428832a8f16e237bfc94e82