### PR TITLE
Clear profiles on startup

### DIFF
--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -9,6 +9,7 @@ from tkinter import scrolledtext
 from typing import Dict, List, Tuple, Optional
 
 from .chat import ChatSession, FakeUser
+from .profile import ProfileStore
 from .ai import AIClient
 from .matcher import Matcher
 from .personas import PERSONAS, Persona
@@ -263,6 +264,9 @@ class PersonaChatPane(ChatPane):
 
 def run_app() -> None:
     """Display the user and persona chats side-by-side."""
+    # Start with a clean set of user profiles for quick iteration.
+    ProfileStore().clear()
+
     root = tk.Tk()
     root.title("TalkMatch")
 

--- a/talkmatch/profile.py
+++ b/talkmatch/profile.py
@@ -36,3 +36,8 @@ class ProfileStore:
         if not path.exists():
             return ""
         return path.read_text(encoding="utf-8")
+
+    def clear(self) -> None:
+        """Remove all stored profile files."""
+        for file in self.base_dir.glob("*.txt"):
+            file.unlink()

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -27,3 +27,11 @@ def test_profile_store_uses_message_placeholder(tmp_path):
     prompt = ai.last_messages[0]["content"]
     assert "<USER INFO:existing profile>" in prompt
     assert "<CHAT MESSAGES:second message>" in prompt
+
+
+def test_clear_removes_profiles(tmp_path):
+    store = ProfileStore(base_dir=tmp_path)
+    path = tmp_path / "user.txt"
+    path.write_text("data", encoding="utf-8")
+    store.clear()
+    assert not any(tmp_path.glob("*.txt"))


### PR DESCRIPTION
## Summary
- add `ProfileStore.clear` to remove saved profile files
- clear existing profiles when launching the app for a clean run
- test profile clearing helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68955b85d71c832a90d8749a5abfb35b