### PR TITLE
feat: persist chat history

### DIFF
--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -54,9 +54,15 @@ class ChatWindow(tk.Toplevel):
 
         tk.Button(self, text="Show Profile", command=self.show_profile).pack(pady=(0, 5))
 
-        greeting = make_greeting(USER_NAME)
-        self.display_message("Ambassador", greeting)
-        self.session.messages.append({"role": "assistant", "content": greeting})
+        if len(self.session.messages) > 1:
+            for msg in self.session.messages[1:]:
+                role = USER_NAME if msg["role"] == "user" else "Other"
+                self.display_message(role, msg["content"])
+        else:
+            greeting = make_greeting(USER_NAME)
+            self.display_message("Ambassador", greeting)
+            self.session.messages.append({"role": "assistant", "content": greeting})
+            self.session.save_history()
         self.protocol("WM_DELETE_WINDOW", self.close)
 
     def display_message(self, role: str, content: str) -> None:
@@ -206,7 +212,7 @@ class UserChatPane(ChatPane):
     """Chat pane for the real user with text input."""
 
     def __init__(self, master: tk.Misc):
-        session = ChatSession(AIClient())
+        session = ChatSession(AIClient(), history_path=Path("chat_history.json"))
         super().__init__(master, session, USER_NAME)
         self.entry = tk.Entry(self, font=("Helvetica", 10))
         self.entry.pack(fill=tk.X, padx=5, pady=5)
@@ -215,9 +221,15 @@ class UserChatPane(ChatPane):
         self.add_profile_button()
         self.add_match_area()
 
-        greeting = make_greeting(USER_NAME)
-        self.display_message("Ambassador", greeting)
-        self.session.messages.append({"role": "assistant", "content": greeting})
+        if len(self.session.messages) > 1:
+            for msg in self.session.messages[1:]:
+                role = USER_NAME if msg["role"] == "user" else "Ambassador"
+                self.display_message(role, msg["content"])
+        else:
+            greeting = make_greeting(USER_NAME)
+            self.display_message("Ambassador", greeting)
+            self.session.messages.append({"role": "assistant", "content": greeting})
+            self.session.save_history()
 
     def send(self) -> None:
         text = self.entry.get().strip()

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -20,7 +20,11 @@ class DummyAI:
 
 def test_chat_session_uses_ai(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
-    session = ChatSession(ai_client=DummyAI(["Stored profile", "AI reply"]), profile_store=store)
+    session = ChatSession(
+        ai_client=DummyAI(["Stored profile", "AI reply"]),
+        profile_store=store,
+        history_path=tmp_path / "history.json",
+    )
     reply = session.send_client_message("Alice", "Hello")
     assert reply == "AI reply"
     assert (tmp_path / "Alice.txt").read_text().strip() == "Stored profile"
@@ -28,7 +32,11 @@ def test_chat_session_uses_ai(tmp_path):
 
 def test_chat_session_switch_to_fake_user(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
-    session = ChatSession(ai_client=DummyAI(["Stored profile"]), profile_store=store)
+    session = ChatSession(
+        ai_client=DummyAI(["Stored profile"]),
+        profile_store=store,
+        history_path=tmp_path / "history.json",
+    )
     fake = FakeUser(["Hi I'm fake"])
     session.switch_to_fake_user(fake)
     reply = session.send_client_message("Bob", "Hello")
@@ -40,9 +48,30 @@ def test_chat_session_tracks_persona_messages(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
     (tmp_path / "Alex.txt").write_text("Profile", encoding="utf-8")
     session = ChatSession(
-        ai_client=DummyAI(["Stored profile", "AI reply"]), profile_store=store
+        ai_client=DummyAI(["Stored profile", "AI reply"]),
+        profile_store=store,
+        history_path=tmp_path / "history.json",
     )
     session.set_persona("Alex")
     reply = session.send_client_message("Alice", "Hi")
     assert reply == "AI reply"
     assert session.persona_message_counts["Alex"] == 1
+
+
+def test_chat_session_persists_history(tmp_path):
+    store = ProfileStore(base_dir=tmp_path)
+    history = tmp_path / "history.json"
+    session1 = ChatSession(
+        ai_client=DummyAI(["profile1", "reply1"]),
+        profile_store=store,
+        history_path=history,
+    )
+    session1.send_client_message("Alice", "Hello")
+    assert history.exists()
+
+    session2 = ChatSession(
+        ai_client=DummyAI(["profile2", "reply2"]),
+        profile_store=store,
+        history_path=history,
+    )
+    assert session2.messages[1]["content"] == "Hello"


### PR DESCRIPTION
## Summary
- persist chat messages to optional JSON file and reload on startup
- show saved conversation history in GUI chat panes
- cover chat persistence with tests and tidy imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68955fb29410832ab41c59f26fb7800f