### PR TITLE
Clarify profile prompt template

### DIFF
--- a/talkmatch/build_profile.txt
+++ b/talkmatch/build_profile.txt
@@ -5,7 +5,10 @@ Based on this additional chat information, update the info as necessary. Focus o
 - that helps the AI know the person as well as possible for eventually matching with other users
 The profile is not displayed to the user, so favor high information density over presentation. Also, don't make assumptions.
 Here's what we already have collected about the user so far:
-<USER INFO:{info}>
+<USER_INFO>{info}</USER_INFO>
 
 Here's the latest chat messages (don't dilute existing information too much):
-<CHAT MESSAGES:{messages}>
+<CHAT_MESSAGES>{messages}</CHAT_MESSAGES>
+
+Return only the updated profile formatted exactly as:
+<USER_INFO>new information</USER_INFO>

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -20,10 +20,12 @@ class CaptureAI:
 
 
 def test_profile_store_uses_message_placeholder(tmp_path):
-    ai = CaptureAI(["existing profile", "updated profile"])
+    ai = CaptureAI(
+        ["<USER_INFO>existing profile</USER_INFO>", "<USER_INFO>updated profile</USER_INFO>"]
+    )
     store = ProfileStore(base_dir=tmp_path)
     store.update(ai, "user", "first message")
     store.update(ai, "user", "second message")
     prompt = ai.last_messages[0]["content"]
-    assert "<USER INFO:existing profile>" in prompt
-    assert "<CHAT MESSAGES:second message>" in prompt
+    assert "<USER_INFO>existing profile</USER_INFO>" in prompt
+    assert "<CHAT_MESSAGES>second message</CHAT_MESSAGES>" in prompt


### PR DESCRIPTION
## Summary
- Revise profile prompt template to enclose user info and chat messages in XML-style tags and request updated profiles in the same format
- Update placeholder test to reflect new prompt tags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689560ca3a64832ab03ad3aed5f6273a