### PR TITLE
Add clear match matrix button

### DIFF
--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -86,3 +86,8 @@ class ChatSession:
     def set_persona(self, persona: Optional[str]) -> None:
         """Switch the ambassador to act as a given persona."""
         self.matched_persona = persona
+
+    def clear_matches(self) -> None:
+        """Revert to the ambassador persona and clear match tracking."""
+        self.matched_persona = None
+        self.persona_message_counts.clear()

--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -310,8 +310,18 @@ def run_app() -> None:
                 matcher.top_matches(name), message_counts=msg_counts
             )
 
+    def clear() -> None:
+        matcher.clear()
+        user_pane.session.clear_matches()
+        for pane in panes.values():
+            pane.update_match_display([])
+
     tk.Button(root, text="Calculate matches", command=calculate).grid(
         row=1, column=0, columnspan=len(panes), pady=5
+    )
+
+    tk.Button(root, text="Clear matches", command=clear).grid(
+        row=2, column=0, columnspan=len(panes), pady=5
     )
 
     root.mainloop()

--- a/talkmatch/matcher.py
+++ b/talkmatch/matcher.py
@@ -18,6 +18,12 @@ class Matcher:
     def __post_init__(self) -> None:
         self.matrix = {u: {v: 0.0 for v in self.users if v != u} for u in self.users}
 
+    def clear(self) -> None:
+        """Reset all match scores to zero."""
+        for u in self.matrix:
+            for v in self.matrix[u]:
+                self.matrix[u][v] = 0.0
+
     def calculate(self, ai_client: AIClient, profile_store: ProfileStore | None = None) -> None:
         """Ask the AI to rate compatibility for each user pair.
 

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -58,6 +58,20 @@ def test_chat_session_tracks_persona_messages(tmp_path):
     assert session.persona_message_counts["Alex"] == 1
 
 
+def test_clear_matches_resets_persona(tmp_path):
+    store = ProfileStore(base_dir=tmp_path)
+    session = ChatSession(
+        ai_client=DummyAI(["profile", "reply"]),
+        profile_store=store,
+        history_path=tmp_path / "history.json",
+    )
+    session.set_persona("Pat")
+    session.persona_message_counts["Pat"] = 2
+    session.clear_matches()
+    assert session.matched_persona is None
+    assert session.persona_message_counts == {}
+
+
 def test_chat_session_persists_history(tmp_path):
     store = ProfileStore(base_dir=tmp_path)
     history = tmp_path / "history.json"

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -36,3 +36,12 @@ def test_top_matches_use_ai_scores():
 
     assert matcher.top_matches("A", top_n=2) == [("B", 0.9), ("C", 0.6)]
     assert matcher.top_matches("B", top_n=2) == [("A", 0.9), ("C", 0.3)]
+
+
+def test_clear_resets_matrix():
+    matcher = Matcher(["A", "B"])
+    matcher.matrix["A"]["B"] = 0.5
+    matcher.matrix["B"]["A"] = 0.5
+    matcher.clear()
+    assert matcher.matrix["A"]["B"] == 0.0
+    assert matcher.matrix["B"]["A"] == 0.0


### PR DESCRIPTION
## Summary
- add `clear_matches` helper to reset persona tracking
- add `Matcher.clear` for wiping score matrix
- expose a **Clear matches** button in the GUI to revert to ambassador persona
- add tests for matrix and persona reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689566567df8832aac2a4609b2837ce6