### PR TITLE
Refactor GUI into separate persona windows with persistent storage

### DIFF
--- a/talkmatch/gui.py
+++ b/talkmatch/gui.py
@@ -1,24 +1,22 @@
-"""Tkinter GUI for the TalkMatch Phase 0 prototype."""
+"""Tkinter GUI for the TalkMatch demo with separate chat windows."""
 from __future__ import annotations
 
 import threading
 import time
 import tkinter as tk
-from pathlib import Path
 from tkinter import scrolledtext
-from typing import Dict, List, Tuple, Optional
+from pathlib import Path
+from typing import Dict, List, Tuple
 
-from .chat import ChatSession, FakeUser
+from .chat import ChatSession
 from .ai import AIClient
 from .matcher import Matcher
 from .personas import PERSONAS, Persona
+from .persistent import Persistent
 
-
-USER_NAME = "Dominic"
-ROLE_COLORS = {USER_NAME: "blue", "Ambassador": "green", "Other": "purple"}
+ROLE_COLORS = {"Ambassador": "green", "Other": "purple"}
 REPLY_DELAY = 3
 
-# Load the greeting template from a text file and format it with the desired name.
 GREETING_TEMPLATE = Path(__file__).with_name("greeting_template.txt").read_text().strip()
 
 
@@ -26,48 +24,56 @@ def make_greeting(name: str) -> str:
     return GREETING_TEMPLATE.format(name=name)
 
 
-class ChatWindow(tk.Toplevel):
-    """User chat interface."""
+class ChatBox(tk.Toplevel):
+    """A window showing conversation with a single persona."""
 
-    def __init__(self, master: tk.Misc, session: ChatSession, on_close=None):
+    def __init__(self, master: tk.Misc, persona: Persona, session: ChatSession):
         super().__init__(master)
+        self.persona = persona
         self.session = session
-        self._on_close = on_close
-        self.title("TalkMatch Chat")
-        self.geometry("250x500")
+        self.persona_ai = AIClient()
+        self.client_name = persona.name
 
-        tk.Label(self, text=USER_NAME, font=("Helvetica", 10, "bold")).pack()
+        self.title(persona.name)
+        self.geometry("300x500")
+
+        tk.Label(self, text=persona.name, font=("Helvetica", 10, "bold")).pack()
         self.chat_area = scrolledtext.ScrolledText(
             self, state="disabled", width=40, font=("Helvetica", 10), wrap=tk.WORD
         )
-        self.chat_area.tag_config(USER_NAME, foreground=ROLE_COLORS[USER_NAME])
-        self.chat_area.tag_config("Ambassador", foreground=ROLE_COLORS["Ambassador"])
-        self.chat_area.tag_config("Other", foreground=ROLE_COLORS["Other"])
         self.chat_area.pack(fill=tk.BOTH, expand=True)
 
         self.entry = tk.Entry(self, font=("Helvetica", 10))
         self.entry.pack(fill=tk.X, padx=5, pady=5)
         self.entry.bind("<Return>", lambda event: self.send_message())
 
-        send_btn = tk.Button(self, text="Send", command=self.send_message)
-        send_btn.pack(pady=(0, 5))
+        btn_frame = tk.Frame(self)
+        btn_frame.pack(pady=(0, 5))
+        tk.Button(btn_frame, text="Send", command=self.send_message).pack(side=tk.LEFT, padx=5)
+        tk.Button(btn_frame, text="Next", command=self.next_message).pack(side=tk.LEFT, padx=5)
+        tk.Button(btn_frame, text="Show Profile", command=self.show_profile).pack(
+            side=tk.LEFT, padx=5
+        )
 
-        tk.Button(self, text="Show Profile", command=self.show_profile).pack(pady=(0, 5))
+        self.match_area = tk.Text(
+            self, state="disabled", height=5, font=("Helvetica", 9), wrap=tk.WORD
+        )
+        self.match_area.pack(fill=tk.BOTH, expand=False, padx=5, pady=5)
+
+        ROLE_COLORS[persona.name] = "blue" if persona.name == "Dominic" else "purple"
 
         if len(self.session.messages) > 1:
             for msg in self.session.messages[1:]:
-                role = USER_NAME if msg["role"] == "user" else "Other"
+                role = persona.name if msg["role"] == "user" else "Ambassador"
                 self.display_message(role, msg["content"])
         else:
-            greeting = make_greeting(USER_NAME)
+            greeting = make_greeting(persona.name)
             self.display_message("Ambassador", greeting)
             self.session.messages.append({"role": "assistant", "content": greeting})
             self.session.save_history()
-        self.protocol("WM_DELETE_WINDOW", self.close)
 
     def display_message(self, role: str, content: str) -> None:
         self.chat_area.configure(state="normal")
-        # Tk tag names cannot contain spaces, so sanitize the role name for tagging
         tag_role = role.replace(" ", "_")
         name_tag = f"{tag_role}_name"
         if name_tag not in self.chat_area.tag_names():
@@ -86,201 +92,15 @@ class ChatWindow(tk.Toplevel):
         if not text:
             return
         self.entry.delete(0, tk.END)
-        self.display_message(USER_NAME, text)
+        self.display_message(self.persona.name, text)
 
         def run() -> None:
             time.sleep(REPLY_DELAY)
-            reply = self.session.send_client_message(USER_NAME, text)
-            role = self.session.matched_persona or "Other"
-            self.after(0, lambda: self.display_message(role, reply))
-
-        threading.Thread(target=run, daemon=True).start()
-
-    def show_profile(self) -> None:
-        data = self.session.profile_store.read(USER_NAME)
-        popup = tk.Toplevel(self)
-        popup.title("Known about you")
-        tk.Message(popup, text=data or "No data yet.", width=300).pack(padx=10, pady=10)
-
-    def close(self) -> None:
-        if self._on_close:
-            self._on_close()
-        self.destroy()
-
-
-class AdminWindow(tk.Toplevel):
-    """Simple admin panel to trigger fake user responses."""
-
-    def __init__(self, master: tk.Misc, session: ChatSession):
-        super().__init__(master)
-        self.session = session
-        self.title("Admin Panel")
-        self.geometry("300x200")
-
-        tk.Label(self, text="Admin Controls").pack(pady=10)
-        tk.Button(
-            self,
-            text="Switch to Fake User",
-            command=self.trigger_fake_user,
-        ).pack(pady=5)
-
-    def trigger_fake_user(self) -> None:
-        fake = FakeUser([
-            "Hi! I'm the fake match.",
-            "What do you like to do for fun?",
-        ])
-        self.session.switch_to_fake_user(fake)
-
-
-class LoginWindow:
-    """Starting point with simple login buttons."""
-
-    def __init__(self, root: tk.Tk, session: ChatSession):
-        self.root = root
-        self.session = session
-        self.chat_window = None
-        root.title("TalkMatch")
-        root.geometry("300x150")
-
-        tk.Button(root, text="User Login", command=self.open_chat).pack(pady=10)
-        tk.Button(root, text="Admin Login", command=self.open_admin).pack(pady=10)
-
-    def open_chat(self) -> None:
-        if self.chat_window and self.chat_window.winfo_exists():
-            self.chat_window.lift()
-            return
-        self.chat_window = ChatWindow(self.root, self.session, on_close=self._chat_closed)
-
-    def open_admin(self) -> None:
-        AdminWindow(self.root, self.session)
-
-    def _chat_closed(self) -> None:
-        self.chat_window = None
-
-
-class ChatPane(tk.Frame):
-    """Base frame for displaying a single chat conversation."""
-
-    def __init__(self, master: tk.Misc, session: ChatSession, title: str):
-        super().__init__(master)
-        self.session = session
-        self.client_name = title
-        tk.Label(self, text=title, font=("Helvetica", 10, "bold")).pack()
-        self.chat_area = scrolledtext.ScrolledText(
-            self, state="disabled", width=40, height=20, font=("Helvetica", 10), wrap=tk.WORD
-        )
-        self.chat_area.pack(fill=tk.BOTH, expand=True)
-        self.match_area = tk.Text(
-            self, state="disabled", height=5, font=("Helvetica", 9), wrap=tk.WORD
-        )
-
-    def add_profile_button(self) -> None:
-        tk.Button(self, text="Show Profile", command=self.show_profile).pack(pady=(0, 5))
-
-    def add_match_area(self) -> None:
-        self.match_area.pack(fill=tk.BOTH, expand=False, padx=5, pady=5)
-
-    def update_match_display(
-        self,
-        matches: List[Tuple[str, float]],
-        message_counts: Optional[Dict[Tuple[str, str], int]] = None,
-    ) -> None:
-        self.match_area.configure(state="normal")
-        self.match_area.delete("1.0", tk.END)
-        for name, score in matches:
-            count = 0
-            if message_counts:
-                key = tuple(sorted([self.client_name, name]))
-                count = message_counts.get(key, 0)
-            self.match_area.insert(tk.END, f"{name}: {score:.2f} ({count} msgs)\n")
-        self.match_area.configure(state="disabled")
-
-    def show_profile(self) -> None:
-        data = self.session.profile_store.read(self.client_name)
-        popup = tk.Toplevel(self)
-        popup.title(f"{self.client_name} profile")
-        tk.Message(popup, text=data or "No data yet.", width=300).pack(padx=10, pady=10)
-
-    def display_message(self, role: str, content: str) -> None:
-        self.chat_area.configure(state="normal")
-        # Ensure tag names are valid by removing spaces
-        tag_role = role.replace(" ", "_")
-        name_tag = f"{tag_role}_name"
-        if name_tag not in self.chat_area.tag_names():
-            color = ROLE_COLORS.get(role, "purple")
-            self.chat_area.tag_config(tag_role, foreground=color)
-            self.chat_area.tag_config(
-                name_tag, foreground=color, font=("Helvetica", 10, "bold")
-            )
-        self.chat_area.insert(tk.END, f"{role}: ", name_tag)
-        self.chat_area.insert(tk.END, f"{content}\n\n", tag_role)
-        self.chat_area.configure(state="disabled")
-        self.chat_area.yview(tk.END)
-
-
-class UserChatPane(ChatPane):
-    """Chat pane for the real user with text input."""
-
-    def __init__(self, master: tk.Misc):
-        session = ChatSession(AIClient(), history_path=Path("chat_history.json"))
-        super().__init__(master, session, USER_NAME)
-        self.entry = tk.Entry(self, font=("Helvetica", 10))
-        self.entry.pack(fill=tk.X, padx=5, pady=5)
-        self.entry.bind("<Return>", lambda event: self.send())
-        tk.Button(self, text="Send", command=self.send).pack(pady=(0, 5))
-        self.add_profile_button()
-        self.add_match_area()
-
-        if len(self.session.messages) > 1:
-            for msg in self.session.messages[1:]:
-                role = USER_NAME if msg["role"] == "user" else "Ambassador"
-                self.display_message(role, msg["content"])
-        else:
-            greeting = make_greeting(USER_NAME)
-            self.display_message("Ambassador", greeting)
-            self.session.messages.append({"role": "assistant", "content": greeting})
-            self.session.save_history()
-
-    def send(self) -> None:
-        text = self.entry.get().strip()
-        if not text:
-            return
-        self.entry.delete(0, tk.END)
-        self.display_message(USER_NAME, text)
-
-        def run() -> None:
-            time.sleep(REPLY_DELAY)
-            reply = self.session.send_client_message(USER_NAME, text)
+            reply = self.session.send_client_message(self.persona.name, text)
             role = self.session.matched_persona or "Ambassador"
             self.after(0, lambda: self.display_message(role, reply))
 
         threading.Thread(target=run, daemon=True).start()
-
-
-class PersonaChatPane(ChatPane):
-    """Chat pane representing an AI persona chatting with the assistant."""
-
-    def __init__(self, master: tk.Misc, persona: Persona):
-        history_file = Path(
-            f"chat_history_{persona.name.replace(' ', '_').lower()}.json"
-        )
-        session = ChatSession(AIClient(), history_path=history_file)
-        super().__init__(master, session, persona.name)
-        self.persona = persona
-        self.persona_ai = AIClient()
-        tk.Button(self, text="Next", command=self.next_message).pack(pady=(0, 5))
-        self.add_profile_button()
-        self.add_match_area()
-
-        if len(self.session.messages) > 1:
-            for msg in self.session.messages[1:]:
-                role = persona.name if msg["role"] == "user" else "Ambassador"
-                self.display_message(role, msg["content"])
-        else:
-            greeting = make_greeting(persona.name)
-            self.display_message("Ambassador", greeting)
-            self.session.messages.append({"role": "assistant", "content": greeting})
-            self.session.save_history()
 
     def next_message(self) -> None:
         def worker() -> None:
@@ -298,58 +118,90 @@ class PersonaChatPane(ChatPane):
 
         threading.Thread(target=worker, daemon=True).start()
 
+    def show_profile(self) -> None:
+        data = self.session.profile_store.read(self.persona.name)
+        popup = tk.Toplevel(self)
+        popup.title(f"{self.persona.name} profile")
+        tk.Message(popup, text=data or "No data yet.", width=300).pack(padx=10, pady=10)
+
+    def update_match_display(
+        self,
+        matches: List[Tuple[str, float]],
+        message_counts: Dict[Tuple[str, str], int] | None = None,
+    ) -> None:
+        self.match_area.configure(state="normal")
+        self.match_area.delete("1.0", tk.END)
+        for name, score in matches:
+            count = 0
+            if message_counts:
+                key = tuple(sorted([self.client_name, name]))
+                count = message_counts.get(key, 0)
+            self.match_area.insert(tk.END, f"{name}: {score:.2f} ({count} msgs)\n")
+        self.match_area.configure(state="disabled")
+
+
+class ControlPanel(tk.Tk):
+    """Main control panel that spawns chat windows and manages matches."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("TalkMatch Control Panel")
+        self.persistent = Persistent()
+        self.profile_store = self.persistent.profile_store()
+        ChatSession.message_counts = self.persistent.load_message_counts()
+
+        self.personas = PERSONAS
+        self.sessions: Dict[str, ChatSession] = {}
+        self.windows: Dict[str, ChatBox] = {}
+
+        for persona in self.personas:
+            session = ChatSession(
+                AIClient(),
+                profile_store=self.profile_store,
+                history_path=self.persistent.chat_history_path(persona.name),
+                persistent=self.persistent,
+            )
+            self.sessions[persona.name] = session
+            win = ChatBox(self, persona, session)
+            self.windows[persona.name] = win
+
+        self.matcher = Matcher(
+            [p.name for p in self.personas], path=self.persistent.match_matrix_path()
+        )
+
+        for session in self.sessions.values():
+            session.update_callback = self.refresh_matches
+
+        tk.Button(self, text="Calculate matches", command=self.calculate).pack(
+            padx=10, pady=5
+        )
+        tk.Button(self, text="Clear matches", command=self.clear).pack(padx=10, pady=5)
+
+        self.refresh_matches()
+
+    def calculate(self) -> None:
+        self.matcher.calculate(AIClient(), profile_store=self.profile_store)
+        top = self.matcher.top_matches("Dominic", 1)
+        if top and top[0][1] > 0:
+            self.sessions["Dominic"].set_persona(top[0][0])
+        else:
+            self.sessions["Dominic"].set_persona(None)
+        self.refresh_matches()
+
+    def clear(self) -> None:
+        self.matcher.clear()
+        self.sessions["Dominic"].set_persona(None)
+        ChatSession.message_counts.clear()
+        self.persistent.save_message_counts({})
+        self.refresh_matches()
+
+    def refresh_matches(self) -> None:
+        msg_counts = ChatSession.message_counts
+        for name, win in self.windows.items():
+            win.update_match_display(
+                self.matcher.top_matches(name), message_counts=msg_counts
+            )
+
 
 def run_app() -> None:
-    """Display the user and persona chats side-by-side."""
-    root = tk.Tk()
-    root.title("TalkMatch")
-
-    all_users = [USER_NAME] + [p.name for p in PERSONAS]
-    matcher = Matcher(all_users)
-    panes: Dict[str, ChatPane] = {}
-
-    user_pane = UserChatPane(root)
-    user_pane.grid(row=0, column=0, padx=5, pady=5)
-    panes[USER_NAME] = user_pane
-
-    for idx, persona in enumerate(PERSONAS, start=1):
-        pane = PersonaChatPane(root, persona)
-        pane.grid(row=0, column=idx, padx=5, pady=5)
-        panes[persona.name] = pane
-
-    def refresh_matches() -> None:
-        def do_refresh() -> None:
-            msg_counts = ChatSession.message_counts
-            for name, pane in panes.items():
-                pane.update_match_display(
-                    matcher.top_matches(name), message_counts=msg_counts
-                )
-
-        root.after(0, do_refresh)
-
-    for pane in panes.values():
-        pane.session.update_callback = refresh_matches
-
-    def calculate() -> None:
-        matcher.calculate(AIClient())
-        top = matcher.top_matches(USER_NAME, 1)
-        if top and top[0][1] > 0:
-            user_pane.session.set_persona(top[0][0])
-        else:
-            user_pane.session.set_persona(None)
-        refresh_matches()
-
-    def clear_matches() -> None:
-        matcher.clear()
-        user_pane.session.set_persona(None)
-        ChatSession.message_counts.clear()
-        refresh_matches()
-
-    tk.Button(root, text="Calculate matches", command=calculate).grid(
-        row=1, column=0, columnspan=len(panes), pady=5
-    )
-    tk.Button(root, text="Clear matches", command=clear_matches).grid(
-        row=2, column=0, columnspan=len(panes), pady=5
-    )
-
-    root.mainloop()
+    ControlPanel().mainloop()

--- a/talkmatch/persistent.py
+++ b/talkmatch/persistent.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Simple persistence layer for TalkMatch.
+
+This class centralizes all file system interactions so it can later be
+replaced by a real database."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Tuple
+import json
+
+from .profile import ProfileStore
+
+
+@dataclass
+class Persistent:
+    base_dir: Path = Path("data")
+
+    def __post_init__(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    # Profile storage -------------------------------------------------
+    def profile_store(self) -> ProfileStore:
+        return ProfileStore(base_dir=self.base_dir / "profiles")
+
+    # Chat histories --------------------------------------------------
+    def chat_history_path(self, name: str) -> Path:
+        return self.base_dir / "chats" / f"{name}.json"
+
+    # Match matrix ----------------------------------------------------
+    def match_matrix_path(self) -> Path:
+        return self.base_dir / "match_matrix.json"
+
+    # Message counts --------------------------------------------------
+    def message_counts_path(self) -> Path:
+        return self.base_dir / "message_counts.json"
+
+    def load_message_counts(self) -> Dict[Tuple[str, str], int]:
+        path = self.message_counts_path()
+        if not path.exists():
+            return {}
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return {tuple(k.split("|")): v for k, v in raw.items()}
+
+    def save_message_counts(self, counts: Dict[Tuple[str, str], int]) -> None:
+        path = self.message_counts_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        raw = {"|".join(k): v for k, v in counts.items()}
+        path.write_text(json.dumps(raw), encoding="utf-8")

--- a/talkmatch/persona_descriptions/Dominic.txt
+++ b/talkmatch/persona_descriptions/Dominic.txt
@@ -1,0 +1,1 @@
+Dominic is a dad of 3 kids and a tech entrepreneur that likes robotics, running, gym, and family time. To unwind he likes camping and watching good movies. He wants to find a cuddle buddy that lives nearby to share cosy moments. He can't host because he lives with his partner but always willing to commute.


### PR DESCRIPTION
## Summary
- Unify user and AI personas into identical `ChatBox` windows with manual or automatic messaging
- Add `Persistent` layer for profiles, chat histories, match matrix, and message counts
- Introduce Dominic persona description and separate control panel for match management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68956e0083ac832aafbc0a570f47fac3