### PR TITLE
centralize static prompt loading

### DIFF
--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import List, Dict, Optional, Callable
 
 from .ai import AIClient
 from .storage import ProfileStore, ChatStore, MessageCountStore
 from .fake_user import FakeUser
+from .prompts import AMBASSADOR_ROLE
 
-# Load the ambassador role description from a text file to keep the code tidy.
-AMBASSADOR_ROLE = Path(__file__).with_name("ambassador_role.txt").read_text().strip()
 
 
 @dataclass

--- a/talkmatch/gui/chat_box.py
+++ b/talkmatch/gui/chat_box.py
@@ -5,22 +5,17 @@ from __future__ import annotations
 import threading
 import time
 import tkinter as tk
-from pathlib import Path
 from tkinter import scrolledtext
 from typing import Dict, List, Tuple
 
 from ..ai import AIClient
 from ..chat import ChatSession
 from ..personas import Persona
+from ..prompts import GREETING_TEMPLATE
 
 ROLE_COLORS = {"Ambassador": "green", "Other": "purple"}
 # Shorten the pause before the AI responds so conversations feel snappier.
 REPLY_DELAY = 1
-
-GREETING_TEMPLATE = (
-    Path(__file__).resolve().parent.parent.joinpath("greeting_template.txt").read_text().strip()
-)
-
 
 def make_greeting(name: str) -> str:
     return GREETING_TEMPLATE.format(name=name)

--- a/talkmatch/personas.py
+++ b/talkmatch/personas.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 """Definitions for AI dating personas used in the demo."""
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import List
+
+from .prompts import PERSONA_DESCRIPTIONS
 
 
 @dataclass
@@ -26,11 +27,10 @@ class Persona:
 
 
 def load_personas() -> List[Persona]:
-    """Load persona descriptions from text files."""
-    base = Path(__file__).with_name("persona_descriptions")
+    """Create Persona objects from the loaded descriptions."""
     personas: List[Persona] = []
-    for path in sorted(base.glob("*.txt")):
-        personas.append(Persona(name=path.stem, description=path.read_text().strip()))
+    for name in sorted(PERSONA_DESCRIPTIONS):
+        personas.append(Persona(name=name, description=PERSONA_DESCRIPTIONS[name]))
     return personas
 
 

--- a/talkmatch/prompts.py
+++ b/talkmatch/prompts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Load static text prompts for the TalkMatch project."""
+
+from pathlib import Path
+from typing import Dict
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _load_text(path: Path) -> str:
+    """Return the file contents or an empty string if missing."""
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+AMBASSADOR_ROLE: str = _load_text(BASE_DIR / "ambassador_role.txt")
+GREETING_TEMPLATE: str = _load_text(BASE_DIR / "greeting_template.txt")
+BUILD_PROFILE_PROMPT: str = _load_text(BASE_DIR / "build_profile.txt")
+
+PERSONA_DESCRIPTIONS: Dict[str, str] = {}
+_persona_dir = BASE_DIR / "persona_descriptions"
+if _persona_dir.exists():
+    for path in sorted(_persona_dir.glob("*.txt")):
+        try:
+            PERSONA_DESCRIPTIONS[path.stem] = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue

--- a/talkmatch/storage/profiles.py
+++ b/talkmatch/storage/profiles.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..ai import AIClient
+from ..prompts import BUILD_PROFILE_PROMPT
 from . import BASE_DIR
 
 
@@ -14,9 +15,7 @@ class ProfileStore:
     """Persist conversation summaries per user."""
 
     base_dir: Path = BASE_DIR / "profiles"
-    prompt_template: str = (
-        (Path(__file__).resolve().parents[1] / "build_profile.txt").read_text(encoding="utf-8")
-    )
+    prompt_template: str = BUILD_PROFILE_PROMPT
 
     def __post_init__(self) -> None:
         self.base_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- add `prompts` module to load ambassador role, greeting template, build profile, and persona descriptions once with safe fallbacks
- replace scattered `Path.read_text` usage with imports from `prompts`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68960470b198832aae587b55799be9a8