### PR TITLE
Refactor GUI to use session manager

### DIFF
--- a/talkmatch/gui/control_panel.py
+++ b/talkmatch/gui/control_panel.py
@@ -4,44 +4,24 @@ from __future__ import annotations
 import tkinter as tk
 from typing import Dict
 
-from ..ai import AIClient
-from ..chat import ChatSession
-from ..storage import (
-    ChatStore,
-    MessageCountStore,
-    ProfileStore,
-    BASE_DIR,
-)
-from ..matcher import Matcher
-from ..personas import PERSONAS
-
+from ..session_manager import SessionManager
 from .chat_box import ChatBox
 
 
 class ControlPanel(tk.Tk):
-    """Main control panel that spawns chat windows and manages matches."""
+    """Main control panel that spawns chat windows and delegates logic."""
 
-    def __init__(self) -> None:
+    def __init__(self, manager: SessionManager | None = None) -> None:
         super().__init__()
         self.title("TalkMatch Control Panel")
         # Position the control panel and chat windows so they do not overlap.
         self.geometry("300x200+20+50")
-        self.profile_store = ProfileStore()
-        self.message_counts = MessageCountStore()
 
-        self.personas = PERSONAS
-        self.sessions: Dict[str, ChatSession] = {}
+        self.session_manager = manager or SessionManager()
         self.windows: Dict[str, ChatBox] = {}
 
-        for idx, persona in enumerate(self.personas):
-            history = ChatStore(path=BASE_DIR / "chats" / f"{persona.name}.json")
-            session = ChatSession(
-                AIClient(),
-                profile_store=self.profile_store,
-                chat_store=history,
-                message_counts=self.message_counts,
-            )
-            self.sessions[persona.name] = session
+        for idx, persona in enumerate(self.session_manager.personas):
+            session = self.session_manager.sessions[persona.name]
             win = ChatBox(self, persona, session)
             # Arrange chat windows horizontally with a small gap.
             win.geometry(f"+{350 + idx * 320}+50")
@@ -50,12 +30,7 @@ class ControlPanel(tk.Tk):
         # When any window is restored, keep the whole set of windows on top.
         self.bind("<Map>", lambda event: self.bring_all_to_front())
 
-        self.matcher = Matcher(
-            [p.name for p in self.personas], path=BASE_DIR / "match_matrix.json"
-        )
-
-        for session in self.sessions.values():
-            session.update_callback = self.refresh_matches
+        self.session_manager.update_callback = self.update_match_display
 
         tk.Button(self, text="Calculate matches", command=self.calculate).pack(
             padx=10, pady=5
@@ -65,27 +40,18 @@ class ControlPanel(tk.Tk):
         self.refresh_matches()
 
     def calculate(self) -> None:
-        self.matcher.calculate(AIClient(), profile_store=self.profile_store)
-        for persona in self.personas:
-            top = self.matcher.top_matches(persona.name, 1)
-            if top and top[0][1] > 0:
-                self.sessions[persona.name].set_persona(top[0][0])
-            else:
-                self.sessions[persona.name].set_persona(None)
-        self.refresh_matches()
+        self.session_manager.calculate()
 
     def clear(self) -> None:
-        self.matcher.clear()
-        for session in self.sessions.values():
-            session.set_persona(None)
-        self.message_counts.clear()
-        self.refresh_matches()
+        self.session_manager.clear()
 
     def refresh_matches(self) -> None:
-        msg_counts = self.message_counts.counts
+        self.session_manager.refresh_matches()
+
+    def update_match_display(self, matches, message_counts) -> None:
         for name, win in self.windows.items():
             win.controller.update_match_display(
-                self.matcher.top_matches(name), message_counts=msg_counts
+                matches.get(name, []), message_counts=message_counts
             )
 
     def bring_all_to_front(self) -> None:
@@ -99,4 +65,5 @@ class ControlPanel(tk.Tk):
 
 
 def run_app() -> None:
-    ControlPanel().mainloop()
+    manager = SessionManager()
+    ControlPanel(manager).mainloop()

--- a/talkmatch/session_manager.py
+++ b/talkmatch/session_manager.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Manage chat sessions, matches, and message counts."""
+
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from .ai import AIClient
+from .chat import ChatSession
+from .matcher import Matcher
+from .personas import PERSONAS, Persona
+from .storage import ChatStore, MessageCountStore, ProfileStore, BASE_DIR
+
+
+class SessionManager:
+    """Handle persona sessions and matchmaking independent of the GUI."""
+
+    def __init__(
+        self,
+        personas: List[Persona] = PERSONAS,
+        base_dir: Path = BASE_DIR,
+        ai_client_factory: Callable[[], AIClient] = AIClient,
+    ) -> None:
+        self.personas = personas
+        self.base_dir = base_dir
+        self.ai_client_factory = ai_client_factory
+        self.profile_store = ProfileStore(base_dir=base_dir / "profiles")
+        self.message_counts = MessageCountStore(path=base_dir / "message_counts.json")
+        self.sessions: Dict[str, ChatSession] = {}
+        self.matcher = Matcher(
+            [p.name for p in personas], path=base_dir / "match_matrix.json"
+        )
+        self.update_callback: Optional[
+            Callable[[Dict[str, List[Tuple[str, float]]], Dict[Tuple[str, str], int]], None]
+        ] = None
+        for persona in personas:
+            history = ChatStore(path=base_dir / "chats" / f"{persona.name}.json")
+            session = ChatSession(
+                ai_client=self.ai_client_factory(),
+                profile_store=self.profile_store,
+                chat_store=history,
+                message_counts=self.message_counts,
+            )
+            session.update_callback = self.refresh_matches
+            self.sessions[persona.name] = session
+
+    # Public API ---------------------------------------------------------
+    def calculate(self) -> None:
+        """Compute matches and assign personas to sessions."""
+        ai = self.ai_client_factory()
+        self.matcher.calculate(ai, profile_store=self.profile_store)
+        for persona in self.personas:
+            top = self.matcher.top_matches(persona.name, 1)
+            session = self.sessions[persona.name]
+            if top and top[0][1] > 0:
+                session.set_persona(top[0][0])
+            else:
+                session.set_persona(None)
+        self.refresh_matches()
+
+    def clear(self) -> None:
+        """Reset matches and message counts."""
+        self.matcher.clear()
+        for session in self.sessions.values():
+            session.set_persona(None)
+        self.message_counts.clear()
+        self.refresh_matches()
+
+    def refresh_matches(
+        self,
+    ) -> Tuple[Dict[str, List[Tuple[str, float]]], Dict[Tuple[str, str], int]]:
+        """Return match data and invoke any registered callback."""
+        matches = {name: self.matcher.top_matches(name) for name in self.sessions}
+        counts = self.message_counts.counts
+        if self.update_callback:
+            self.update_callback(matches, counts)
+        return matches, counts

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,45 @@
+from talkmatch.session_manager import SessionManager
+from talkmatch.personas import Persona
+
+
+class DummyAI:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get_response(self, messages):
+        return self.responses.pop(0) if self.responses else ""
+
+
+class DummyFactory:
+    def __init__(self, responses_per_client):
+        self.responses_per_client = responses_per_client
+
+    def __call__(self):
+        responses = self.responses_per_client.pop(0)
+        return DummyAI(responses)
+
+
+def test_session_manager_handles_matches_and_counts(tmp_path):
+    personas = [Persona("A", "a"), Persona("B", "b")]
+    factory = DummyFactory([
+        ["profile", "reply"],  # AI for session A
+        [],                      # AI for session B
+        ["0.8"],                 # AI for matcher
+    ])
+    manager = SessionManager(personas=personas, base_dir=tmp_path, ai_client_factory=factory)
+    captured = {}
+    manager.update_callback = lambda m, c: captured.update({"matches": m, "counts": c})
+
+    manager.calculate()
+    assert manager.sessions["A"].matched_persona == "B"
+    assert manager.sessions["B"].matched_persona == "A"
+    pair = tuple(sorted(["A", "B"]))
+    assert captured["matches"]["A"][0][0] == "B"
+
+    manager.sessions["A"].send_client_message("A", "Hi")
+    assert manager.message_counts.counts[pair] == 1
+    assert captured["counts"][pair] == 1
+
+    manager.clear()
+    assert manager.sessions["A"].matched_persona is None
+    assert manager.message_counts.counts == {}


### PR DESCRIPTION
## Summary
- add `SessionManager` class to handle persona sessions, matchmaking and message counts
- refactor `ControlPanel` to delegate session logic to `SessionManager`
- cover new behavior with `SessionManager` unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68960f0e3290832ab509ce649d52a301