### PR TITLE
Label ambassador actions in chat UI

### DIFF
--- a/talkmatch/chat.py
+++ b/talkmatch/chat.py
@@ -23,6 +23,7 @@ class ChatSession:
     )
     fake_user: Optional[FakeUser] = None
     matched_persona: Optional[str] = None
+    ambassador_status: str = field(init=False, default="")
     update_callback: Optional[Callable[[], None]] = None
 
     def __post_init__(self) -> None:
@@ -30,6 +31,7 @@ class ChatSession:
             loaded = self.chat_store.load()
             if loaded:
                 self.messages = loaded
+        self.set_persona(None)
 
     def send_client_message(self, name: str, text: str) -> str:
         """Handle a message from any client (user or persona)."""
@@ -62,6 +64,17 @@ class ChatSession:
     def switch_to_fake_user(self, fake_user: FakeUser) -> None:
         self.fake_user = fake_user
 
+    def set_status(self, status: str) -> None:
+        """Update the ambassador's activity label."""
+        self.ambassador_status = status
+
+    def ambassador_label(self) -> str:
+        return f"Ambassador [{self.ambassador_status}]"
+
     def set_persona(self, persona: Optional[str]) -> None:
         """Switch the ambassador to act as a given persona."""
         self.matched_persona = persona
+        if persona:
+            self.set_status(f"acting as {persona}")
+        else:
+            self.set_status("collecting info")

--- a/talkmatch/gui/chat_box.py
+++ b/talkmatch/gui/chat_box.py
@@ -63,12 +63,12 @@ class ChatBox(tk.Toplevel):
                 role = (
                     persona.name
                     if msg["role"] == "user"
-                    else self.controller.ambassador_name()
+                    else self.controller.ambassador_label()
                 )
                 self.display_message(role, msg["content"])
         else:
             greeting = make_greeting(persona.name)
-            self.display_message(self.controller.ambassador_name(), greeting)
+            self.display_message(self.controller.ambassador_label(), greeting)
             self.session.messages.append({"role": "assistant", "content": greeting})
             self.session.save_history()
 
@@ -76,10 +76,16 @@ class ChatBox(tk.Toplevel):
         if not content.strip():
             content = "Empty response"
         self.chat_area.configure(state="normal")
-        tag_role = role.replace(" ", "_").replace("(", "").replace(")", "")
+        tag_role = (
+            role.replace(" ", "_")
+            .replace("(", "")
+            .replace(")", "")
+            .replace("[", "")
+            .replace("]", "")
+        )
         name_tag = f"{tag_role}_name"
         if name_tag not in self.chat_area.tag_names():
-            base_role = role.split(" (", 1)[0]
+            base_role = role.split(" [", 1)[0]
             color = ROLE_COLORS.get(base_role, "purple")
             self.chat_area.tag_config(tag_role, foreground=color)
             self.chat_area.tag_config(

--- a/talkmatch/gui/persona_controller.py
+++ b/talkmatch/gui/persona_controller.py
@@ -26,10 +26,8 @@ class PersonaChatController:
         self.persona_ai = AIClient()
         self.client_name = persona.name
 
-    def ambassador_name(self) -> str:
-        if self.session.matched_persona:
-            return f"Ambassador ({self.session.matched_persona})"
-        return "Ambassador"
+    def ambassador_label(self) -> str:
+        return self.session.ambassador_label()
 
     def send_message(self, text: str) -> None:
         self.chat_box.display_message(self.persona.name, text)
@@ -38,7 +36,7 @@ class PersonaChatController:
             time.sleep(REPLY_DELAY)
             reply = self.session.send_client_message(self.persona.name, text)
             self.chat_box.after(
-                0, lambda: self.chat_box.display_message(self.ambassador_name(), reply)
+                0, lambda: self.chat_box.display_message(self.ambassador_label(), reply)
             )
 
         threading.Thread(target=run, daemon=True).start()
@@ -58,7 +56,7 @@ class PersonaChatController:
                 self.chat_box.after(
                     0,
                     lambda: self.chat_box.display_message(
-                        self.ambassador_name(), reply
+                        self.ambassador_label(), reply
                     ),
                 )
 


### PR DESCRIPTION
## Summary
- show ambassador messages with activity brackets like `[collecting info]` or `[acting as Dominic]`
- centralize ambassador status tracking in `ChatSession`
- update GUI components to render the new labels
- initialize status via `set_persona` to avoid repeating the `collecting info` string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689618fd72a0832aa49bc07b9a417f96