### PR TITLE
Add profile readiness evaluator

### DIFF
--- a/talkmatch/readiness.py
+++ b/talkmatch/readiness.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Evaluate whether a user's profile satisfies key objectives."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+from .ai import AIClient
+from .profile import ProfileStore
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _load_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+READINESS_PROMPT = _load_text(BASE_DIR / "readiness_prompt.txt")
+
+
+@dataclass
+class ReadinessEvaluator:
+    """Evaluate profile readiness using an AI model."""
+
+    ai_client: AIClient
+    prompt_template: str = READINESS_PROMPT
+
+    def score(self, objectives: Sequence[str], profile: str) -> float:
+        prompt = self.prompt_template.replace("{objectives}", "\n".join(objectives)).replace(
+            "{profile}", profile
+        )
+        response = self.ai_client.get_response([
+            {"role": "user", "content": prompt}
+        ])
+        try:
+            return float(response.strip())
+        except ValueError:
+            return 0.0
+
+    def is_ready(self, objectives: Sequence[str], profile: str) -> bool:
+        return self.score(objectives, profile) >= 80.0
+
+
+try:  # Import may be provided by another task.
+    from .profile_objectives import PROFILE_OBJECTIVES
+except Exception:  # pragma: no cover - optional dependency
+    PROFILE_OBJECTIVES: Sequence[str] = []
+
+
+def is_ready(name: str, profile_store: ProfileStore, ai_client: AIClient) -> bool:
+    """Return True if the user's profile covers most objectives."""
+
+    evaluator = ReadinessEvaluator(ai_client)
+    profile_text = profile_store.read(name)
+    return evaluator.is_ready(PROFILE_OBJECTIVES, profile_text)

--- a/talkmatch/readiness_prompt.txt
+++ b/talkmatch/readiness_prompt.txt
@@ -1,0 +1,9 @@
+Evaluate how well the following dating profile text covers each objective listed.
+
+Objectives:
+{objectives}
+
+Profile:
+{profile}
+
+Return only an integer from 0 to 100 representing the percentage of objectives addressed.

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from talkmatch.profile import ProfileStore
+from talkmatch import readiness
+
+
+class DummyAI:
+    def __init__(self, response: str):
+        self.response = response
+        self.last_messages = None
+
+    def get_response(self, messages):
+        self.last_messages = messages
+        return self.response
+
+
+def test_is_ready_true(tmp_path, monkeypatch):
+    ai = DummyAI("80")
+    store = ProfileStore(base_dir=tmp_path)
+    store.profiles["alice"] = "loves hiking"
+    monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
+    assert readiness.is_ready("alice", store, ai)
+    prompt = ai.last_messages[0]["content"]
+    assert "hiking" in prompt
+    assert "loves hiking" in prompt
+
+
+def test_is_ready_false(tmp_path, monkeypatch):
+    ai = DummyAI("79")
+    store = ProfileStore(base_dir=tmp_path)
+    store.profiles["bob"] = "likes movies"
+    monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
+    assert not readiness.is_ready("bob", store, ai)


### PR DESCRIPTION
## Summary
- Add `ReadinessEvaluator` that loads a prompt template and scores profile coverage of objectives
- Provide readiness prompt template for AI evaluation
- Introduce tests for readiness evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68962b3bef10832aa788b867b2945f92