### PR TITLE
Add user filtering and readiness checks to matchmaking

### DIFF
--- a/talkmatch/filters.py
+++ b/talkmatch/filters.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""User list filters for matchmaking."""
+
+from typing import Protocol, List
+
+from .ai import AIClient
+from .profile import ProfileStore
+from .readiness import ReadinessEvaluator, PROFILE_OBJECTIVES
+
+
+class UserFilter(Protocol):
+    """Filter a list of user names."""
+
+    def filter(self, users: List[str]) -> List[str]:
+        """Return a subset of ``users``."""
+
+
+class ReadinessFilter(UserFilter):
+    """Filter out users whose profiles are not ready."""
+
+    def __init__(self, ai_client: AIClient, profile_store: ProfileStore) -> None:
+        self.evaluator = ReadinessEvaluator(ai_client)
+        self.profile_store = profile_store
+
+    def filter(self, users: List[str]) -> List[str]:
+        return [
+            name
+            for name in users
+            if self.evaluator.is_ready(
+                PROFILE_OBJECTIVES, self.profile_store.read(name)
+            )
+        ]

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -38,6 +38,16 @@ def test_top_matches_use_ai_scores():
     assert matcher.top_matches("B", top_n=2) == [("A", 0.9), ("C", 0.3)]
 
 
+def test_calculate_subset_of_users(tmp_path):
+    users = ["A", "B", "C"]
+    matcher = Matcher(users, path=tmp_path / "matrix.json")
+    ai = DummyAI(["0.7"])
+    store = DummyStore({"A": "a", "B": "b", "C": "c"})
+    matcher.calculate(ai, profile_store=store, users=["A", "B"])
+    assert matcher.top_matches("A", top_n=2)[0] == ("B", 0.7)
+    assert matcher.matrix["A"]["C"] == 0.0
+
+
 def test_match_matrix_persistence(tmp_path):
     path = tmp_path / "matrix.json"
     users = ["A", "B"]

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -5,20 +5,21 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from talkmatch.profile import ProfileStore
 from talkmatch import readiness
+from talkmatch import filters as user_filters
 
 
 class DummyAI:
-    def __init__(self, response: str):
-        self.response = response
+    def __init__(self, responses: list[str]):
+        self.responses = responses
         self.last_messages = None
 
     def get_response(self, messages):
         self.last_messages = messages
-        return self.response
+        return self.responses.pop(0)
 
 
 def test_is_ready_true(tmp_path, monkeypatch):
-    ai = DummyAI("80")
+    ai = DummyAI(["80"])
     store = ProfileStore(base_dir=tmp_path)
     store.profiles["alice"] = "loves hiking"
     monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
@@ -29,8 +30,17 @@ def test_is_ready_true(tmp_path, monkeypatch):
 
 
 def test_is_ready_false(tmp_path, monkeypatch):
-    ai = DummyAI("79")
+    ai = DummyAI(["79"])
     store = ProfileStore(base_dir=tmp_path)
     store.profiles["bob"] = "likes movies"
     monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
     assert not readiness.is_ready("bob", store, ai)
+
+
+def test_readiness_filter_filters_users(tmp_path, monkeypatch):
+    store = ProfileStore(base_dir=tmp_path)
+    store.profiles["alice"] = "hiking"
+    store.profiles["bob"] = "movies"
+    monkeypatch.setattr(user_filters, "PROFILE_OBJECTIVES", ["hiking"])
+    filt = user_filters.ReadinessFilter(DummyAI(["80", "79"]), store)
+    assert filt.filter(["alice", "bob"]) == ["alice"]

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -39,3 +39,23 @@ def test_session_manager_handles_matches(tmp_path):
 
     manager.clear()
     assert manager.sessions["A"].matched_persona is None
+
+
+class ExcludeBFilter:
+    def filter(self, users):
+        return [u for u in users if u != "B"]
+
+
+def test_session_manager_applies_filters(tmp_path):
+    personas = [Persona("A", "a"), Persona("B", "b")]
+    factory = DummyFactory([
+        [],  # AI for session A
+        [],  # AI for session B
+        [],  # AI for matcher
+    ])
+    manager = SessionManager(
+        personas=personas, base_dir=tmp_path, ai_client_factory=factory, filters=[ExcludeBFilter()]
+    )
+    manager.calculate()
+    assert manager.sessions["A"].matched_persona is None
+    assert manager.sessions["B"].matched_persona is None


### PR DESCRIPTION
## Summary
- Add `UserFilter` protocol and a `ReadinessFilter` that screens personas using `ReadinessEvaluator`
- Allow `SessionManager` and `Matcher` to operate on filtered user subsets
- Cover new behavior with tests for filtering and subset matching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68962d58ca44832aabd6460cb9085343