### PR TITLE
Add profile objectives and collect info guidance

### DIFF
--- a/talkmatch/collect_info_prompt.txt
+++ b/talkmatch/collect_info_prompt.txt
@@ -1,0 +1,1 @@
+Casually steer the conversation to learn these details if missing: {objectives}. Ask naturally and avoid sounding like a questionnaire.

--- a/talkmatch/objectives.py
+++ b/talkmatch/objectives.py
@@ -1,0 +1,13 @@
+"""Compatibility criteria for building user profiles."""
+
+PROFILE_OBJECTIVES = [
+    "kids",  # whether they want children
+    "job",  # occupation or career goals
+    "values",  # core beliefs and priorities
+    "relationship style",  # monogamy vs ethical non-monogamy
+    "kinkiness",  # comfort with kink or BDSM
+    "sexual preferences",  # orientation and desires
+    "age",  # current age
+    "desired age range",  # preferred partner age range
+    "languages",  # languages spoken
+]

--- a/talkmatch/prompts.py
+++ b/talkmatch/prompts.py
@@ -19,6 +19,7 @@ def _load_text(path: Path) -> str:
 AMBASSADOR_ROLE: str = _load_text(BASE_DIR / "ambassador_role.txt")
 GREETING_TEMPLATE: str = _load_text(BASE_DIR / "greeting_template.txt")
 BUILD_PROFILE_PROMPT: str = _load_text(BASE_DIR / "build_profile.txt")
+COLLECT_INFO_PROMPT: str = _load_text(BASE_DIR / "collect_info_prompt.txt")
 
 PERSONA_DESCRIPTIONS: Dict[str, str] = {}
 _persona_dir = BASE_DIR / "persona_descriptions"


### PR DESCRIPTION
## Summary
- define PROFILE_OBJECTIVES covering key compatibility criteria
- load collect-info prompt and attach system message with outstanding objectives when no persona is matched
- add test ensuring collect-info prompt is added to messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68962fdfbdb4832abb8209c56995ba6e