### PR TITLE
Add readiness evaluation and session manager filter tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture
+def objectives():
+    return ["hiking"]
+
+
+@pytest.fixture
+def ready_profile():
+    return "loves hiking"
+
+
+@pytest.fixture
+def unready_profile():
+    return "likes movies"

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,46 +1,20 @@
-import os
-import sys
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-from talkmatch.profile import ProfileStore
-from talkmatch import readiness
-from talkmatch import filters as user_filters
+import pytest
+from talkmatch.readiness import ReadinessEvaluator
 
 
 class DummyAI:
-    def __init__(self, responses: list[str]):
+    def __init__(self, responses):
         self.responses = responses
-        self.last_messages = None
 
     def get_response(self, messages):
-        self.last_messages = messages
         return self.responses.pop(0)
 
 
-def test_is_ready_true(tmp_path, monkeypatch):
-    ai = DummyAI(["80"])
-    store = ProfileStore(base_dir=tmp_path)
-    store.profiles["alice"] = "loves hiking"
-    monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
-    assert readiness.is_ready("alice", store, ai)
-    prompt = ai.last_messages[0]["content"]
-    assert "hiking" in prompt
-    assert "loves hiking" in prompt
+def test_is_ready_true(objectives, ready_profile):
+    evaluator = ReadinessEvaluator(DummyAI(["80"]))
+    assert evaluator.is_ready(objectives, ready_profile)
 
 
-def test_is_ready_false(tmp_path, monkeypatch):
-    ai = DummyAI(["79"])
-    store = ProfileStore(base_dir=tmp_path)
-    store.profiles["bob"] = "likes movies"
-    monkeypatch.setattr(readiness, "PROFILE_OBJECTIVES", ["hiking"])
-    assert not readiness.is_ready("bob", store, ai)
-
-
-def test_readiness_filter_filters_users(tmp_path, monkeypatch):
-    store = ProfileStore(base_dir=tmp_path)
-    store.profiles["alice"] = "hiking"
-    store.profiles["bob"] = "movies"
-    monkeypatch.setattr(user_filters, "PROFILE_OBJECTIVES", ["hiking"])
-    filt = user_filters.ReadinessFilter(DummyAI(["80", "79"]), store)
-    assert filt.filter(["alice", "bob"]) == ["alice"]
+def test_is_ready_false(objectives, unready_profile):
+    evaluator = ReadinessEvaluator(DummyAI(["79"]))
+    assert not evaluator.is_ready(objectives, unready_profile)

--- a/tests/test_session_manager_filters.py
+++ b/tests/test_session_manager_filters.py
@@ -1,0 +1,51 @@
+import pytest
+from talkmatch.session_manager import SessionManager
+from talkmatch.personas import Persona
+from talkmatch import filters
+
+
+class DummyAI:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get_response(self, messages):
+        return self.responses.pop(0) if self.responses else ""
+
+
+class DummyFactory:
+    def __init__(self, responses_per_client):
+        self.responses_per_client = responses_per_client
+
+    def __call__(self):
+        responses = self.responses_per_client.pop(0)
+        return DummyAI(responses)
+
+
+def test_session_manager_respects_readiness_filter(
+    tmp_path, objectives, ready_profile, unready_profile, monkeypatch
+):
+    personas = [Persona("A", "a"), Persona("B", "b"), Persona("C", "c")]
+    factory = DummyFactory([
+        [],  # AI for session A
+        [],  # AI for session B
+        [],  # AI for session C
+        ["0.9"],  # AI for matcher (A vs C)
+    ])
+    manager = SessionManager(personas=personas, base_dir=tmp_path, ai_client_factory=factory)
+
+    manager.profile_store.profiles.update({
+        "A": ready_profile,
+        "B": unready_profile,
+        "C": ready_profile,
+    })
+
+    monkeypatch.setattr(filters, "PROFILE_OBJECTIVES", objectives)
+    readiness_ai = DummyAI(["80", "79", "80"])
+    readiness_filter = filters.ReadinessFilter(readiness_ai, manager.profile_store)
+    manager.filters = [readiness_filter]
+
+    manager.calculate()
+
+    assert manager.sessions["A"].matched_persona == "C"
+    assert manager.sessions["C"].matched_persona == "A"
+    assert manager.sessions["B"].matched_persona is None


### PR DESCRIPTION
## Summary
- test ReadinessEvaluator.is_ready with stubbed AI scores
- verify SessionManager.calculate respects ReadinessFilter readiness
- share fixtures for objectives and profile data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689632bfe77c832aa80d7314158ab7e9