### PR TITLE
Add ambassador state machine and linking workflow

### DIFF
--- a/talkmatch/ambassador.py
+++ b/talkmatch/ambassador.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Ambassador state machine for chat sessions."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Ambassador:
+    """Handle ambassador states and labels."""
+
+    state: str = "collecting_info"
+    persona: Optional[str] = None
+    link_target: Optional[str] = None
+    link_context: Optional[str] = None
+
+    def set_persona(self, persona: Optional[str]) -> None:
+        """Switch to acting as ``persona`` or reset to collecting info."""
+        self.persona = persona
+        self.link_target = None
+        self.link_context = None
+        if persona:
+            self.state = "acting"
+        else:
+            self.state = "collecting_info"
+
+    def begin_link(self, other: str, context: str) -> None:
+        """Enter linking mode with ``other`` using their recent context."""
+        self.link_target = other
+        self.link_context = context
+        self.state = "linking"
+
+    def finalize_link(self) -> None:
+        """Move to linked mode once conversations converge."""
+        self.state = "linked"
+
+    def declare_match(self, other: str) -> None:
+        """Record that an official match has occurred with ``other``."""
+        self.link_target = other
+        self.state = "matched"
+
+    def status(self) -> str:
+        """Return a descriptive label for the current state."""
+        if self.state == "acting" and self.persona:
+            return f"acting as {self.persona}"
+        if self.state == "linking" and self.link_target:
+            return f"trying to link with {self.link_target}"
+        if self.state == "linked" and self.link_target:
+            return f"linked with {self.link_target}"
+        if self.state == "matched" and self.link_target:
+            return f"matched with {self.link_target}"
+        return "collecting info"

--- a/talkmatch/gui/chat_box.py
+++ b/talkmatch/gui/chat_box.py
@@ -10,7 +10,12 @@ from ..personas import Persona
 from ..prompts import GREETING_TEMPLATE
 from .persona_controller import PersonaChatController
 
-ROLE_COLORS = {"Ambassador": "green", "Other": "purple"}
+ROLE_COLORS = {
+    "Ambassador [trying": "orange",
+    "Ambassador [linked": "blue",
+    "Ambassador": "green",
+    "Other": "purple",
+}
 
 def make_greeting(name: str) -> str:
     return GREETING_TEMPLATE.format(name=name)
@@ -85,8 +90,11 @@ class ChatBox(tk.Toplevel):
         )
         name_tag = f"{tag_role}_name"
         if name_tag not in self.chat_area.tag_names():
-            base_role = role.split(" [", 1)[0]
-            color = ROLE_COLORS.get(base_role, "purple")
+            color = "purple"
+            for prefix, val in ROLE_COLORS.items():
+                if role.startswith(prefix):
+                    color = val
+                    break
             self.chat_area.tag_config(tag_role, foreground=color)
             self.chat_area.tag_config(
                 name_tag, foreground=color, font=("Helvetica", 10, "bold")

--- a/talkmatch/matcher.py
+++ b/talkmatch/matcher.py
@@ -70,6 +70,8 @@ class Matcher:
         profiles = {user: store.read(user) for user in target_users}
         for i, u in enumerate(target_users):
             for v in target_users[i + 1 :]:
+                if self.matrix.get(u, {}).get(v, 0.0) >= 1.0:
+                    continue
                 prompt = build_prompt(u, v, profiles)
                 reply = ai_client.get_response([{"role": "user", "content": prompt}])
                 score = _parse_score(reply)
@@ -81,3 +83,8 @@ class Matcher:
         """Return the top ``top_n`` matches for ``user``."""
         scores = self.matrix.get(user, {})
         return sorted(scores.items(), key=lambda item: item[1], reverse=True)[:top_n]
+
+    def declare_official_match(self, a: str, b: str) -> None:
+        self.matrix.setdefault(a, {})[b] = 1.0
+        self.matrix.setdefault(b, {})[a] = 1.0
+        self._save()

--- a/tests/test_linking_workflow.py
+++ b/tests/test_linking_workflow.py
@@ -1,0 +1,55 @@
+from talkmatch.session_manager import SessionManager
+from talkmatch.personas import Persona
+
+
+class DummyAI:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get_response(self, messages):
+        return self.responses.pop(0) if self.responses else ""
+
+
+class DummyFactory:
+    def __init__(self, responses_per_client):
+        self.responses_per_client = responses_per_client
+
+    def __call__(self):
+        responses = self.responses_per_client.pop(0)
+        return DummyAI(responses)
+
+
+def test_linking_progression(tmp_path):
+    personas = [Persona("A", "a"), Persona("B", "b")]
+    factory = DummyFactory([
+        ["p1", "r1", "p2", "r2"],  # session A
+        ["p3", "r3", "p4", "r4"],  # session B
+        ["0.8"],  # matcher
+    ])
+    manager = SessionManager(personas=personas, base_dir=tmp_path, ai_client_factory=factory, filters=[], link_threshold=2)
+    manager.calculate()
+    manager.send_message("A", "hi")
+    manager.send_message("B", "hello")
+    assert manager.sessions["A"].ambassador.state == "acting"
+    manager.send_message("A", "pizza")
+    manager.send_message("B", "pizza")
+    assert manager.sessions["A"].ambassador.state == "linked"
+    assert manager.sessions["B"].ambassador.state == "linked"
+
+
+def test_official_match_blocks_impersonation(tmp_path):
+    personas = [Persona("A", "a"), Persona("B", "b")]
+    factory = DummyFactory([
+        [],  # session A
+        [],  # session B
+        ["0.8"],  # matcher first
+        [],  # matcher second (skipped due to official match)
+    ])
+    manager = SessionManager(personas=personas, base_dir=tmp_path, ai_client_factory=factory, filters=[])
+    manager.calculate()
+    assert manager.sessions["A"].ambassador.persona == "B"
+    manager.declare_match("A", "B")
+    manager.calculate()
+    assert manager.sessions["A"].ambassador.persona is None
+    assert manager.sessions["B"].ambassador.persona is None
+    assert manager.matcher.matrix["A"]["B"] == 1.0

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -31,14 +31,14 @@ def test_session_manager_handles_matches(tmp_path):
     manager.update_callback = lambda m: captured.update({"matches": m})
 
     manager.calculate()
-    assert manager.sessions["A"].matched_persona == "B"
-    assert manager.sessions["B"].matched_persona == "A"
+    assert manager.sessions["A"].ambassador.persona == "B"
+    assert manager.sessions["B"].ambassador.persona == "A"
     assert captured["matches"]["A"][0][0] == "B"
 
     manager.sessions["A"].send_client_message("A", "Hi")
 
     manager.clear()
-    assert manager.sessions["A"].matched_persona is None
+    assert manager.sessions["A"].ambassador.persona is None
 
 
 class ExcludeBFilter:
@@ -60,8 +60,8 @@ def test_session_manager_applies_filters(tmp_path):
         filters=[ExcludeBFilter()],
     )
     manager.calculate()
-    assert manager.sessions["A"].matched_persona is None
-    assert manager.sessions["B"].matched_persona is None
+    assert manager.sessions["A"].ambassador.persona is None
+    assert manager.sessions["B"].ambassador.persona is None
 
 
 def test_no_impersonation_on_low_match(tmp_path):
@@ -75,5 +75,5 @@ def test_no_impersonation_on_low_match(tmp_path):
         personas=personas, base_dir=tmp_path, ai_client_factory=factory, filters=[]
     )
     manager.calculate()
-    assert manager.sessions["A"].matched_persona is None
-    assert manager.sessions["B"].matched_persona is None
+    assert manager.sessions["A"].ambassador.persona is None
+    assert manager.sessions["B"].ambassador.persona is None

--- a/tests/test_session_manager_filters.py
+++ b/tests/test_session_manager_filters.py
@@ -46,6 +46,6 @@ def test_session_manager_respects_readiness_filter(
 
     manager.calculate()
 
-    assert manager.sessions["A"].matched_persona == "C"
-    assert manager.sessions["C"].matched_persona == "A"
-    assert manager.sessions["B"].matched_persona is None
+    assert manager.sessions["A"].ambassador.persona == "C"
+    assert manager.sessions["C"].ambassador.persona == "A"
+    assert manager.sessions["B"].ambassador.persona is None


### PR DESCRIPTION
## Summary
- Introduce `Ambassador` class implementing `collecting_info`, `acting`, `linking`, `linked`, and `matched` states.
- Delegate `ChatSession` and `SessionManager` to the ambassador, enabling linking mode with cross-user context, link finalization, and official match recording.
- Update GUI coloring for new linking states and persist official matches in matcher logic.
- Add tests covering linking transitions and official match exclusion.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68963c7aed8c832abaa30d7355c094b1