### PR TITLE
Log readiness evaluation results

### DIFF
--- a/talkmatch/readiness.py
+++ b/talkmatch/readiness.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
+import logging
 
 from .ai import AIClient
 from .profile import ProfileStore
+
+
+logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -42,7 +46,10 @@ class ReadinessEvaluator:
             return 0.0
 
     def is_ready(self, objectives: Sequence[str], profile: str) -> bool:
-        return self.score(objectives, profile) >= 80.0
+        score = self.score(objectives, profile)
+        ready = score >= 80.0
+        logger.info("Readiness result: score=%s ready=%s", score, ready)
+        return ready
 
 
 try:  # Import may be provided by another task.

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from talkmatch.readiness import ReadinessEvaluator
 
@@ -18,3 +19,10 @@ def test_is_ready_true(objectives, ready_profile):
 def test_is_ready_false(objectives, unready_profile):
     evaluator = ReadinessEvaluator(DummyAI(["79"]))
     assert not evaluator.is_ready(objectives, unready_profile)
+
+
+def test_logs_readiness_result(objectives, ready_profile, caplog):
+    evaluator = ReadinessEvaluator(DummyAI(["80"]))
+    with caplog.at_level(logging.INFO):
+        evaluator.is_ready(objectives, ready_profile)
+    assert any("Readiness result" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- log readiness evaluation score and boolean result for profiles
- add test verifying readiness logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896bc183ec8832ab31a76ffc5a462a0